### PR TITLE
Allow SVG files for Page Builder icons

### DIFF
--- a/class-fw-extension-shortcodes.php
+++ b/class-fw-extension-shortcodes.php
@@ -466,9 +466,9 @@ class FW_Extension_Shortcodes extends FW_Extension
 
 	public function _locate_shortocode_icon($shortcode) {
 		$maybe_svg = $shortcode->locate_URI('/static/img/page_builder.svg');
-		$maybe_png = $shortcode->locate_URI('/static/img/page_builder.png');
 
 		if (! $maybe_svg) {
+			$maybe_png = $shortcode->locate_URI('/static/img/page_builder.png');
 			return $maybe_png;
 		}
 

--- a/class-fw-extension-shortcodes.php
+++ b/class-fw-extension-shortcodes.php
@@ -143,7 +143,7 @@ class FW_Extension_Shortcodes extends FW_Extension
 	public function _parse_single_shortcode( $shortcode ) {
 		$result = array();
 
-		$icon = $shortcode->locate_URI('/static/img/page_builder.png');
+		$icon = $this->_locate_shortocode_icon($shortcode);
 
 		if ($icon) {
 			$result['icon'] = $icon;
@@ -445,7 +445,7 @@ class FW_Extension_Shortcodes extends FW_Extension
 			if (
 				!isset($item_data['icon'])
 				&&
-				($icon = $shortcode->locate_URI('/static/img/page_builder.png'))
+				($icon = $this->_locate_shortocode_icon($shortcode))
 			) {
 				$item_data['icon'] = $icon;
 			}
@@ -462,6 +462,13 @@ class FW_Extension_Shortcodes extends FW_Extension
 
 			return $item_data;
 		}
+	}
+
+	public function _locate_shortocode_icon($shortcode) {
+		$maybe_svg = $shortcode->locate_URI('/static/img/page_builder.svg');
+		$maybe_png = $shortcode->locate_URI('/static/img/page_builder.png');
+
+		return $maybe_svg || $maybe_png;
 	}
 
 	public function add_simple_shortcodes_data_to_filter( $structure ) {

--- a/class-fw-extension-shortcodes.php
+++ b/class-fw-extension-shortcodes.php
@@ -468,7 +468,11 @@ class FW_Extension_Shortcodes extends FW_Extension
 		$maybe_svg = $shortcode->locate_URI('/static/img/page_builder.svg');
 		$maybe_png = $shortcode->locate_URI('/static/img/page_builder.png');
 
-		return $maybe_svg || $maybe_png;
+		if (! $maybe_svg) {
+			return $maybe_png;
+		}
+
+		return $maybe_svg;
 	}
 
 	public function add_simple_shortcodes_data_to_filter( $structure ) {


### PR DESCRIPTION
SVG files are much cheaper to use and they load much faster. Also, they're
support for retina screens is amazing.

This pull request customizes the lookup mechanism of shortcodes for icons.
The used to look for a `page_builder.png` file. Now they look for 2 files,
in that order:

1. `page_builder.svg`
2. `page_builder.png`