### PR TITLE
removing .gitignore file because it ruins version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-extensions/*


### PR DESCRIPTION
The .gitignore file is being installed by this Unyson Extension and messing up the version control in Pantheon so it is not deployed to TEST and LIVE https://github.com/ThemeFuse/Unyson/issues/3615

Hopefully this gitignore file is not included when Unyson Extensions are installed.